### PR TITLE
feat: trace annotation & review UI (feature 009)

### DIFF
--- a/app/components/annotation.py
+++ b/app/components/annotation.py
@@ -1,0 +1,123 @@
+"""Streamlit annotation widgets for trace step reviewer notes."""
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+_SEVERITY_BADGES = {
+    "none": ":gray-badge[none]",
+    "low": ":blue-badge[low]",
+    "medium": ":orange-badge[medium]",
+    "high": ":red-badge[high]",
+}
+
+_SEVERITY_OPTIONS = ["none", "low", "medium", "high"]
+
+
+def _default_reviewer() -> str:
+    """Return reviewer name from session state or system username."""
+    stored = st.session_state.get("inspect_reviewer_id")
+    if stored:
+        return stored
+    try:
+        return os.getlogin()
+    except OSError:
+        return "reviewer"
+
+
+def render_annotation_form(case_id: str, step_id: str) -> None:
+    """Render an Add Note form for a specific trace step.
+
+    On save, calls service.add_annotation() and clears the annotation cache
+    for this case so the list refreshes on next rerun.
+    """
+    from agenteval.core import service
+
+    form_key = f"ann_form_{case_id}_{step_id}"
+    with st.form(key=form_key, clear_on_submit=True):
+        reviewer = st.text_input(
+            "Your name",
+            value=_default_reviewer(),
+            key=f"ann_reviewer_{case_id}_{step_id}",
+        )
+        content = st.text_area(
+            "Note",
+            placeholder="Describe the issue or observation…",
+            key=f"ann_content_{case_id}_{step_id}",
+        )
+        severity = st.selectbox(
+            "Severity",
+            options=_SEVERITY_OPTIONS,
+            key=f"ann_severity_{case_id}_{step_id}",
+        )
+        submitted = st.form_submit_button(":material/save: Save Note", type="primary")
+
+    if submitted:
+        reviewer_val = reviewer.strip()
+        content_val = content.strip()
+        if not reviewer_val:
+            st.error("Reviewer name is required.")
+            return
+        if not content_val:
+            st.error("Note content is required.")
+            return
+        try:
+            service.add_annotation(
+                case_id=case_id,
+                step_id=step_id,
+                reviewer_id=reviewer_val,
+                content=content_val,
+                severity=severity,
+            )
+            # Persist reviewer name across session
+            st.session_state["inspect_reviewer_id"] = reviewer_val
+            # Invalidate annotation cache for this case
+            cache_key = f"annotations_{case_id}"
+            if cache_key in st.session_state:
+                del st.session_state[cache_key]
+            st.success("Note saved.")
+            st.rerun()
+        except ValueError as exc:
+            st.error(f"Could not save note: {exc}")
+
+
+def render_annotation_list(
+    annotations: list[dict],  # type: ignore[type-arg]
+    case_id: str,
+) -> None:
+    """Display existing annotations inline with Delete buttons.
+
+    Args:
+        annotations: List of annotation dicts (from service.get_annotations).
+        case_id: Case ID used to invalidate the cache after delete.
+    """
+    from agenteval.core import service
+
+    if not annotations:
+        return
+
+    for ann in annotations:
+        ann_id = ann["annotation_id"]
+        reviewer = ann.get("reviewer_id", "?")
+        timestamp = ann.get("timestamp", "")[:19].replace("T", " ")
+        content = ann.get("content", "")
+        severity = ann.get("severity", "none")
+        badge = _SEVERITY_BADGES.get(severity, ":gray-badge[?]")
+
+        col_text, col_btn = st.columns([10, 1])
+        with col_text:
+            st.markdown(
+                f"{badge} **{reviewer}** :small[{timestamp} UTC]  \n{content}"
+            )
+        with col_btn:
+            if st.button(
+                ":material/delete:",
+                key=f"del_ann_{ann_id}",
+                help="Delete this note",
+            ):
+                service.delete_annotation(case_id, ann_id)
+                cache_key = f"annotations_{case_id}"
+                if cache_key in st.session_state:
+                    del st.session_state[cache_key]
+                st.rerun()

--- a/app/page_inspect.py
+++ b/app/page_inspect.py
@@ -5,6 +5,8 @@ import json
 
 import streamlit as st
 
+from agenteval.core import service
+from agenteval.core.annotations import build_auto_eval_overlay
 from agenteval.core.service import (
     get_run,
     get_run_results,
@@ -17,6 +19,7 @@ from agenteval.core.service import (
     run_selective_evaluation,
 )
 from agenteval.dataset.validator import _get_repo_root
+from components.annotation import render_annotation_form, render_annotation_list
 from components.help_section import show_help_section
 from onboarding.content import PAGE_HELP
 
@@ -28,30 +31,83 @@ _TYPE_COLORS = {
     "final_answer": "violet",
 }
 
+_SEVERITY_STEP_COLORS = {
+    "flagged": "red",
+    "clean": "green",
+}
 
-def _render_step(step: dict) -> None:  # type: ignore[type-arg]
-    """Render a single trace step."""
+
+def _get_annotations_cached(case_id: str) -> list[dict]:  # type: ignore[type-arg]
+    """Return annotations for a case, cached in session state."""
+    cache_key = f"annotations_{case_id}"
+    if cache_key not in st.session_state:
+        st.session_state[cache_key] = service.get_annotations(case_id)
+    return st.session_state[cache_key]  # type: ignore[no-any-return]
+
+
+def _render_step(
+    step: dict,  # type: ignore[type-arg]
+    overlay_step_evidence: dict,  # type: ignore[type-arg]
+    highlighted_step: str | None,
+    case_id: str,
+    annotations_by_step: dict,  # type: ignore[type-arg]
+) -> None:
+    """Render a single trace step with overlay badges, highlighting, and annotations."""
     step_id = step.get("step_id", "?")
     step_type = step.get("type", "unknown")
     actor = step.get("actor_id", "")
     content = step.get("content", "")
     color = _TYPE_COLORS.get(step_type, "gray")
 
-    st.markdown(f"**`{step_id}`** :{color}[{step_type}] — *{actor}*")
-    st.text(content)
+    is_highlighted = highlighted_step == step_id
+    is_flagged = step_id in overlay_step_evidence
 
-    if step_type == "tool_call":
-        tool_name = step.get("tool_name")
-        tool_input = step.get("tool_input")
-        if tool_name:
-            st.markdown(f"Tool: `{tool_name}`")
-        if tool_input:
-            st.json(tool_input)
+    # Choose container style
+    if is_highlighted:
+        container = st.container(border=True)
+    elif is_flagged:
+        container = st.container(border=True)
+    else:
+        container = st.container()
 
-    if step_type == "observation":
-        tool_output = step.get("tool_output")
-        if tool_output:
-            st.code(str(tool_output), language=None)
+    with container:
+        # Highlight banner
+        if is_highlighted:
+            st.markdown(":violet-background[:material/my_location: Highlighted step]")
+
+        # Step header line
+        dim_badges = ""
+        if is_flagged:
+            dims = overlay_step_evidence[step_id]
+            badges = " ".join(
+                f":red-badge[{d.dimension}: {d.score if d.score is not None else '?'}]"
+                for d in dims
+            )
+            dim_badges = f"  {badges}"
+
+        st.markdown(f"**`{step_id}`** :{color}[{step_type}] — *{actor}*{dim_badges}")
+        st.text(content)
+
+        if step_type == "tool_call":
+            tool_name = step.get("tool_name")
+            tool_input = step.get("tool_input")
+            if tool_name:
+                st.markdown(f"Tool: `{tool_name}`")
+            if tool_input:
+                st.json(tool_input)
+
+        if step_type == "observation":
+            tool_output = step.get("tool_output")
+            if tool_output:
+                st.code(str(tool_output), language=None)
+
+        # Annotations for this step
+        step_annotations = annotations_by_step.get(step_id, [])
+        render_annotation_list(step_annotations, case_id)
+
+        # Add Note expander
+        with st.expander(":material/add_comment: Add Note", expanded=False):
+            render_annotation_form(case_id, step_id)
 
     st.divider()
 
@@ -82,12 +138,30 @@ def _render_cases_tab() -> None:
         )
         return
 
+    # Track previously selected case to clear highlight on change
+    prev_case_key = "inspect_prev_case"
+    prev_case = st.session_state.get(prev_case_key)
+
     selected = st.selectbox("Select a case", cases)
     if not selected:
         return
 
+    # Clear highlighted step when case changes
+    if prev_case != selected:
+        st.session_state["inspect_highlighted_step"] = None
+        st.session_state[prev_case_key] = selected
+
     repo_root = _get_repo_root()
     case_dir = repo_root / "data" / "cases" / selected
+
+    # --- Load auto-eval overlay ---
+    overlay_step_evidence: dict = {}  # type: ignore[type-arg]
+    case_flags = []
+    auto_eval = service.get_auto_eval_for_case(selected)
+    if auto_eval is not None:
+        overlay = build_auto_eval_overlay(auto_eval)
+        overlay_step_evidence = overlay.step_evidence
+        case_flags = overlay.case_flags
 
     # --- Case Metadata ---
     st.subheader("Case Metadata")
@@ -107,17 +181,50 @@ def _render_cases_tab() -> None:
     else:
         st.warning("No metadata found (expected_outcome.md missing or has no header).")
 
+    # --- Sidebar: Evaluation Flags ---
+    if case_flags:
+        with st.sidebar:
+            with st.expander(":material/flag: Evaluation Flags", expanded=True):
+                for flag in case_flags:
+                    score_str = str(flag.score) if flag.score is not None else "?"
+                    st.markdown(
+                        f":red-badge[{flag.dimension}] score={score_str}  \n"
+                        f":small[{flag.notes[:80]}{'…' if len(flag.notes) > 80 else ''}]"
+                    )
+
     # --- Trace Viewer ---
     st.subheader("Trace Steps")
+
+    # Load annotations once, index by step_id
+    all_annotations = _get_annotations_cached(selected)
+    annotations_by_step: dict = {}  # type: ignore[type-arg]
+    for ann in all_annotations:
+        step_id = ann.get("step_id", "")
+        annotations_by_step.setdefault(step_id, []).append(ann)
+
+    highlighted_step: str | None = st.session_state.get("inspect_highlighted_step")
+
     try:
         trace = load_trace(case_dir)
         steps = trace.get("steps", [])
         if not steps:
             st.info("Trace has no steps.")
         else:
+            # Legend when overlay is active
+            if overlay_step_evidence:
+                st.caption(
+                    ":red-badge[dimension: score] = flagged by evaluator  "
+                    "  :violet-background[violet] = jump-to target"
+                )
             for step in steps:
                 if isinstance(step, dict):
-                    _render_step(step)
+                    _render_step(
+                        step,
+                        overlay_step_evidence,
+                        highlighted_step,
+                        selected,
+                        annotations_by_step,
+                    )
     except (json.JSONDecodeError, Exception) as exc:
         st.error(f"Failed to parse trace: {exc}")
 
@@ -176,11 +283,25 @@ def _render_cases_tab() -> None:
                 weight = dim_data.get("weight", 1.0)
                 scale = dim_data.get("scale", "0-2")
                 score_display = str(score) if score is not None else "Not yet scored"
+                evidence_step_ids: list[str] = dim_data.get("evidence_step_ids") or []
 
                 st.markdown(
                     f"**{dim_name}** — Scale: {scale}, Weight: {weight}, "
                     f"Score: **{score_display}**"
                 )
+
+                # US3: Evidence linking — "→ Step" jump buttons
+                if evidence_step_ids:
+                    cols = st.columns(len(evidence_step_ids))
+                    for i, sid in enumerate(evidence_step_ids):
+                        with cols[i]:
+                            if st.button(
+                                f":material/arrow_forward: {sid}",
+                                key=f"jump_{dim_name}_{sid}_{selected}",
+                                help=f"Highlight {sid} in the trace viewer",
+                            ):
+                                st.session_state["inspect_highlighted_step"] = sid
+                                st.rerun()
 
         auto_tags = template.get("auto_tags", [])
         if auto_tags:

--- a/schemas/annotation_schema.json
+++ b/schemas/annotation_schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Annotation File",
+  "description": "Schema for reviewer annotation files stored in reports/{case_id}.annotations.json.",
+  "type": "object",
+  "required": ["case_id", "annotations"],
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Benchmark case identifier."
+    },
+    "annotations": {
+      "type": "array",
+      "description": "Ordered list of reviewer annotations (append-only).",
+      "items": {
+        "type": "object",
+        "required": [
+          "annotation_id",
+          "case_id",
+          "step_id",
+          "reviewer_id",
+          "timestamp",
+          "content",
+          "severity"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "annotation_id": {
+            "type": "string",
+            "pattern": "^ann_[0-9a-f]{8}$",
+            "description": "Unique identifier: ann_ followed by 8 hex characters."
+          },
+          "case_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The case this annotation belongs to."
+          },
+          "step_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The trace step this note references."
+          },
+          "reviewer_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Reviewer identifier (free text)."
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "ISO 8601 UTC timestamp."
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Note text."
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["none", "low", "medium", "high"],
+            "description": "Issue severity level."
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs/009-trace-annotation-review-ui/contracts/library.md
+++ b/specs/009-trace-annotation-review-ui/contracts/library.md
@@ -1,0 +1,95 @@
+# Library Contract: Annotation Module (Feature 009)
+
+## Module: `src/agenteval/core/annotations.py`
+
+---
+
+### `add_annotation(case_id, step_id, reviewer_id, content, severity, repo_root) -> Annotation`
+
+Add a reviewer annotation to a trace step. Appends to the case's annotation file, creating it if absent.
+
+**Parameters**:
+- `case_id: str` — case identifier (must be non-empty)
+- `step_id: str` — trace step identifier (must be non-empty)
+- `reviewer_id: str` — reviewer identifier (must be non-empty)
+- `content: str` — note text (must be non-empty)
+- `severity: Literal["none", "low", "medium", "high"]` — issue severity
+- `repo_root: Path` — repository root for path resolution
+
+**Returns**: `Annotation` — the newly created annotation
+
+**Raises**:
+- `ValueError` if `content`, `case_id`, `step_id`, or `reviewer_id` is empty
+- `ValueError` if `severity` is not a valid value
+
+**Side effects**: Writes to `reports/{case_id}.annotations.json` (creates or appends)
+
+---
+
+### `get_annotations(case_id, repo_root) -> list[Annotation]`
+
+Load all annotations for a case. Returns empty list if no file exists.
+
+**Parameters**:
+- `case_id: str`
+- `repo_root: Path`
+
+**Returns**: `list[Annotation]` — sorted by timestamp ascending
+
+---
+
+### `delete_annotation(case_id, annotation_id, repo_root) -> bool`
+
+Remove an annotation by ID. Returns `True` if deleted, `False` if not found.
+
+**Parameters**:
+- `case_id: str`
+- `annotation_id: str`
+- `repo_root: Path`
+
+**Returns**: `bool`
+
+---
+
+### `build_auto_eval_overlay(auto_eval: dict) -> AutoEvalOverlay`
+
+Derive an overlay from an auto_evaluation dict. Pure function — no I/O.
+
+**Parameters**:
+- `auto_eval: dict` — a loaded `*.auto_evaluation.json` dict
+
+**Returns**: `AutoEvalOverlay` with:
+- `step_evidence`: dict mapping step_id → list of `DimEvidence` that cite it
+- `case_flags`: list of `DimEvidence` for dimensions with scores but no step evidence
+
+---
+
+### `get_auto_eval_for_case(case_id, repo_root) -> dict | None`
+
+Load the best available auto_evaluation for a case. Checks `reports/` first, then scans run directories for the most recent.
+
+**Parameters**:
+- `case_id: str`
+- `repo_root: Path`
+
+**Returns**: `dict | None` — loaded auto_evaluation dict, or None if none exists
+
+---
+
+## Service layer additions: `src/agenteval/core/service.py`
+
+### `get_annotations(case_id) -> list[dict]`
+
+Thin wrapper — delegates to `annotations.get_annotations()`. Returns list of annotation dicts.
+
+### `add_annotation(case_id, step_id, reviewer_id, content, severity) -> dict`
+
+Thin wrapper — delegates to `annotations.add_annotation()`. Returns annotation as dict.
+
+### `delete_annotation(case_id, annotation_id) -> bool`
+
+Thin wrapper — delegates to `annotations.delete_annotation()`.
+
+### `get_auto_eval_for_case(case_id) -> dict | None`
+
+Thin wrapper — delegates to `annotations.get_auto_eval_for_case()`.

--- a/specs/009-trace-annotation-review-ui/data-model.md
+++ b/specs/009-trace-annotation-review-ui/data-model.md
@@ -1,0 +1,125 @@
+# Data Model: Trace Annotation & Review UI (Feature 009)
+
+## Entities
+
+### Annotation
+
+A reviewer note attached to a specific trace step.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `annotation_id` | `str` | Yes | Unique identifier (`ann_<8-hex>`) |
+| `case_id` | `str` | Yes | The case this annotation belongs to |
+| `step_id` | `str` | Yes | The trace step this note references |
+| `reviewer_id` | `str` | Yes | Reviewer identifier (free text) |
+| `timestamp` | `str` | Yes | ISO 8601 UTC timestamp |
+| `content` | `str` | Yes | Note text (non-empty) |
+| `severity` | `str` | Yes | One of: `none`, `low`, `medium`, `high` |
+
+**Storage**: `reports/{case_id}.annotations.json`
+
+**File format**:
+```json
+{
+  "case_id": "case_001",
+  "annotations": [
+    {
+      "annotation_id": "ann_3f7a1b2c",
+      "case_id": "case_001",
+      "step_id": "step_2",
+      "reviewer_id": "alice",
+      "timestamp": "2026-05-04T10:30:00+00:00",
+      "content": "Tool call uses incorrect parameter format",
+      "severity": "high"
+    }
+  ]
+}
+```
+
+---
+
+### AnnotationFile (container)
+
+The top-level file written to disk.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `case_id` | `str` | Yes | Matches the case this file belongs to |
+| `annotations` | `list[Annotation]` | Yes | Ordered list (append-only) |
+
+---
+
+### AutoEvalOverlay (derived, not persisted)
+
+A mapping derived at runtime from an `auto_evaluation.json` file.
+
+| Field | Type | Description |
+|---|---|---|
+| `step_evidence` | `dict[str, list[DimEvidence]]` | step_id → list of dimensions that cite this step |
+| `case_flags` | `list[DimEvidence]` | Dimensions with scores but no step-level evidence |
+
+### DimEvidence (derived)
+
+| Field | Type | Description |
+|---|---|---|
+| `dimension` | `str` | Rubric dimension name |
+| `score` | `int \| None` | Dimension score |
+| `notes` | `str` | Evaluator notes |
+| `evaluator_type` | `str` | `rule` or `llm` |
+
+---
+
+## Python Representations
+
+```python
+# src/agenteval/core/annotations.py
+
+@dataclass(frozen=True)
+class Annotation:
+    annotation_id: str
+    case_id: str
+    step_id: str
+    reviewer_id: str
+    timestamp: str
+    content: str
+    severity: Literal["none", "low", "medium", "high"]
+
+@dataclass(frozen=True)
+class DimEvidence:
+    dimension: str
+    score: int | None
+    notes: str
+    evaluator_type: str
+
+@dataclass(frozen=True)
+class AutoEvalOverlay:
+    step_evidence: dict[str, list[DimEvidence]]   # step_id → dims citing this step
+    case_flags: list[DimEvidence]                  # dims scored but no step evidence
+```
+
+---
+
+## Module Layout
+
+```
+src/agenteval/core/annotations.py    — Annotation dataclass, persistence, overlay builder
+schemas/annotation_schema.json       — JSON Schema for annotation files
+app/components/annotation.py         — Streamlit annotation widget (add/display notes)
+app/page_inspect.py                  — Enhanced: overlay + annotations + evidence linking
+tests/test_annotations.py            — Unit tests for annotations module
+```
+
+---
+
+## Relationships
+
+```
+case_001/trace.json
+    └── steps[]: step_id = "step_1", "step_2", ...
+             ↑ referenced by
+reports/case_001.auto_evaluation.json
+    └── dimensions[tool_use].evidence_step_ids = ["step_2"]
+             ↑ same step_ids
+reports/case_001.annotations.json
+    └── annotations[].step_id = "step_2"
+```

--- a/specs/009-trace-annotation-review-ui/plan.md
+++ b/specs/009-trace-annotation-review-ui/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Trace Annotation & Review UI
+
+**Branch**: `009-trace-annotation-review-ui` | **Date**: 2026-05-04 | **Spec**: `specs/009-trace-annotation-review-ui/spec.md`
+
+## Summary
+
+Enhance the Inspect page with three connected capabilities: (1) inline reviewer annotations on trace steps, persisted to `reports/{case_id}.annotations.json`; (2) auto-score overlay that color-codes steps and shows evaluator evidence inline; (3) evidence linking that highlights cited steps when reviewing evaluation results. Step-level diff view (US4) is deferred — it requires real trace variants that don't yet exist in the dataset.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+, `from __future__ import annotations`
+**Primary Dependencies**: `jsonschema>=4.21.0` (existing), `streamlit>=1.30.0` (UI, optional extra)
+**Storage**: Filesystem — `reports/{case_id}.annotations.json`
+**Testing**: pytest
+**Target Platform**: Local desktop (Streamlit UI + CLI library)
+**Project Type**: Library + Streamlit UI enhancement
+**Performance Goals**: Annotation read/write < 50ms for typical cases (< 50 annotations)
+**Constraints**: No new runtime dependencies; all file I/O within repo root via `_safe_resolve_within()`
+**Scale/Scope**: Single-user lab tool; annotation files are small JSON (< 100 annotations per case typical)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Security First | ✅ PASS | Annotations stored locally; all paths via `_safe_resolve_within()`; no secrets in annotation content at validation time |
+| II. Schema-First | ✅ PASS | `schemas/annotation_schema.json` added; validated on read and write |
+| III. Offline | ✅ PASS | All I/O is local filesystem |
+| IV. Test-Driven | ✅ PASS | `tests/test_annotations.py` required before implementation |
+| V. Minimal Dependencies | ✅ PASS | No new runtime deps |
+| VI. Dataset Completeness | ✅ PASS | Annotations stored in `reports/`, not `data/cases/` |
+| VII. Backward Compatible | ✅ PASS | `page_inspect.py` enhanced, not replaced; existing CLI unaffected |
+| VIII. Library-First | ✅ PASS | All logic in `src/agenteval/core/annotations.py`; UI is thin wrapper |
+
+## Project Structure
+
+```text
+src/agenteval/core/annotations.py     — Annotation dataclass, CRUD, overlay builder
+src/agenteval/core/service.py         — 4 new thin wrapper functions
+schemas/annotation_schema.json        — JSON Schema for annotation files
+app/components/annotation.py          — Streamlit annotation widget
+app/page_inspect.py                   — Enhanced: overlay + annotations + evidence linking
+tests/test_annotations.py             — Unit tests
+specs/009-trace-annotation-review-ui/ — This spec directory
+```
+
+## User Stories
+
+### US1 (P1): Inline Annotations
+Reviewers can add text notes to specific trace steps. Notes persist across sessions and are visible to all reviewers viewing the same case.
+
+**Done when**: Add Note form works; notes survive page reload; `reports/{case_id}.annotations.json` is valid per schema.
+
+### US2 (P1): Auto-Score Overlay
+When an auto-evaluation exists for a case, trace steps are color-coded and evaluator evidence is shown inline.
+
+**Done when**: Steps with `evidence_step_ids` references show a dimension badge; steps without references are clean; case-level flags shown in sidebar; color coding is visible.
+
+### US3 (P2): Evidence Linking
+From the Evaluation section, clicking a cited step highlights it in the trace viewer.
+
+**Done when**: Each `evidence_step_id` in the evaluation template has a "→ Jump" button; clicking it sets `st.session_state.highlighted_step` and the target step renders with a distinct border.
+
+## Architecture Decisions
+
+- **Annotation IDs**: `ann_` + 8 hex chars from `secrets.token_hex(4)`
+- **Timestamps**: `datetime.now(timezone.utc).isoformat()`
+- **Schema validation on write**: validate before writing to disk; fail loudly
+- **Auto-eval lookup**: `reports/{case_id}.auto_evaluation.json` first; then scan `runs/*/` for most recent
+- **highlighted_step**: `st.session_state["inspect_highlighted_step"]` — cleared when case selection changes
+- **Reviewer name persistence**: `st.session_state["inspect_reviewer_id"]` — survives page reruns within session

--- a/specs/009-trace-annotation-review-ui/quickstart.md
+++ b/specs/009-trace-annotation-review-ui/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: Trace Annotation & Review UI (Feature 009)
+
+## Scenario 1: Add an annotation to a trace step
+
+```python
+from pathlib import Path
+from agenteval.core.annotations import add_annotation, get_annotations
+from agenteval.dataset.validator import _get_repo_root
+
+repo_root = _get_repo_root()
+
+# Add a note to step_2 of case_001
+ann = add_annotation(
+    case_id="case_001",
+    step_id="step_2",
+    reviewer_id="alice",
+    content="Tool call uses incorrect parameter format",
+    severity="high",
+    repo_root=repo_root,
+)
+print(ann.annotation_id)  # ann_3f7a1b2c
+
+# Reload all annotations for the case
+annotations = get_annotations("case_001", repo_root)
+print(len(annotations))  # 1
+```
+
+---
+
+## Scenario 2: Build an auto-score overlay
+
+```python
+import json
+from agenteval.core.annotations import get_auto_eval_for_case, build_auto_eval_overlay
+from agenteval.dataset.validator import _get_repo_root
+
+repo_root = _get_repo_root()
+
+auto_eval = get_auto_eval_for_case("case_001", repo_root)
+if auto_eval:
+    overlay = build_auto_eval_overlay(auto_eval)
+
+    # Steps with evidence links
+    for step_id, dims in overlay.step_evidence.items():
+        print(f"{step_id}: flagged by {[d.dimension for d in dims]}")
+
+    # Dimensions scored without step-level evidence
+    for flag in overlay.case_flags:
+        print(f"{flag.dimension}: score={flag.score} ({flag.notes[:40]})")
+```
+
+---
+
+## Scenario 3: UI workflow
+
+1. Open the **Inspect** page
+2. Select a case from the dropdown
+3. Trace steps are displayed with color-coded badges:
+   - 🔴 Step flagged by an evaluator
+   - 🟢 Step clean / no flags
+   - ⚪ No auto-evaluation available
+4. Click **Add Note** on any step to open the annotation form:
+   - Enter your reviewer name (pre-filled from session)
+   - Write your note
+   - Select severity (none / low / medium / high)
+   - Click **Save Note**
+5. Notes appear inline below the step on all subsequent loads
+6. The **Evaluation** section shows which steps each dimension cited as evidence; clicking **→ Step** highlights that step in the trace viewer
+
+---
+
+## Scenario 4: Delete an annotation
+
+```python
+from agenteval.core.annotations import delete_annotation
+from agenteval.dataset.validator import _get_repo_root
+
+deleted = delete_annotation("case_001", "ann_3f7a1b2c", _get_repo_root())
+print(deleted)  # True
+```

--- a/specs/009-trace-annotation-review-ui/research.md
+++ b/specs/009-trace-annotation-review-ui/research.md
@@ -1,0 +1,58 @@
+# Research: Trace Annotation & Review UI (Feature 009)
+
+## Decision: Annotation storage location
+
+**Decision**: `reports/{case_id}.annotations.json`
+**Rationale**: Annotations are review artifacts tied to a specific case, not a specific run. Storing alongside other `reports/` artifacts (`*.evaluation.json`, `*.auto_evaluation.json`) keeps all case-level review data together and matches the existing pattern.
+**Alternatives considered**:
+- `data/cases/{case_id}/annotations.json` — rejected: dataset validator would scan and potentially flag annotation content; case directories are for benchmark inputs only.
+- `runs/{run_id}/{case_id}.annotations.json` — rejected: annotations should persist across runs; tying them to a run would lose them when the run is not selected.
+
+---
+
+## Decision: Auto-evaluation source for overlay
+
+**Decision**: Check `reports/{case_id}.auto_evaluation.json` first; fall back to the most recent run directory containing `{case_id}.auto_evaluation.json`.
+**Rationale**: The `reports/` directory is the canonical output of `agenteval-auto-score` CLI. Run-directory auto_evaluations from the UI are equally valid but secondary. Checking `reports/` first is consistent with `load_evaluation_template()`.
+**Alternatives considered**:
+- Only `reports/` — too restrictive; UI-driven scoring (via `run_selective_evaluation`) writes to the run directory.
+- Only latest run — ignores CLI-scored results; inconsistent with existing service layer patterns.
+
+---
+
+## Decision: reviewer_id source
+
+**Decision**: Simple text input in the UI with a sensible default (system username via `os.getlogin()` with fallback to `"reviewer"`).
+**Rationale**: No authentication exists in the framework; a lightweight string identifier is sufficient for lab/team use. Matches the spirit of the spec without adding an auth dependency.
+**Alternatives considered**:
+- Hardcoded "reviewer" — too opaque for multi-user scenarios.
+- Full user profile system — out of scope; adds complexity with no corresponding value at this stage.
+
+---
+
+## Decision: evidence_step_ids overlay behaviour with empty arrays
+
+**Decision**: When `evidence_step_ids` is empty for a dimension, show the dimension's score and notes at the *case level* (sidebar/expander) rather than on a specific step. When populated, show the dimension badge on the referenced step.
+**Rationale**: Current rule-based evaluators (`ToolUseEvaluator`, `SecurityEvaluator`) leave `evidence_step_ids` empty. The overlay must be useful now while being future-ready for LLM evaluators that will populate step-level evidence.
+**Alternatives considered**:
+- Show nothing when evidence is empty — hides scoring context from reviewers entirely.
+- Distribute score to all steps — misleading; implies all steps caused the score.
+
+---
+
+## Decision: Step-level diff view scope
+
+**Decision**: Defer to a future iteration. Implement US1 (annotations), US2 (auto-score overlay), and US3 (evidence linking) in this feature. US4 (diff view) is P3 and requires trace versioning infrastructure that doesn't yet exist.
+**Rationale**: The diff view requires two traces for the same case from different runs, which is only meaningful when agents actually produce different outputs. With fixed test fixtures, the diff would always be empty. The value is low until real agent iteration is supported.
+**Alternatives considered**:
+- Implement diff view now — adds significant complexity for near-zero practical value in the current dataset.
+
+---
+
+## Decision: "Jump to step" navigation in Streamlit
+
+**Decision**: Use `st.session_state` to set a `highlighted_step` key; steps check this key and render with a visible highlight (colored container border) when selected. No anchor/scroll manipulation needed.
+**Rationale**: Streamlit does not expose native anchor scrolling. Session-state-driven highlighting is idiomatic Streamlit, testable, and reliable across browser environments.
+**Alternatives considered**:
+- JavaScript `window.scrollTo` via `st.components.v1.html` — fragile, depends on DOM structure, unmaintainable.
+- Anchor links with `st.markdown` HTML — not supported in Streamlit's sandbox mode.

--- a/src/agenteval/core/annotations.py
+++ b/src/agenteval/core/annotations.py
@@ -1,0 +1,315 @@
+"""Annotation module: reviewer notes and auto-eval overlay for trace steps."""
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import jsonschema  # type: ignore[import-untyped]
+
+from agenteval.dataset.validator import _get_repo_root, _safe_resolve_within
+
+_VALID_SEVERITIES = ("none", "low", "medium", "high")
+
+# Lazy-cached schema
+_SCHEMA: dict[str, Any] | None = None
+
+
+def _load_schema() -> dict[str, Any]:
+    global _SCHEMA
+    if _SCHEMA is None:
+        repo_root = _get_repo_root()
+        schema_path = repo_root / "schemas" / "annotation_schema.json"
+        _SCHEMA = json.loads(schema_path.read_text(encoding="utf-8"))
+    return _SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Annotation:
+    """A reviewer note attached to a specific trace step."""
+
+    annotation_id: str
+    case_id: str
+    step_id: str
+    reviewer_id: str
+    timestamp: str
+    content: str
+    severity: Literal["none", "low", "medium", "high"]
+
+
+@dataclass(frozen=True)
+class DimEvidence:
+    """Derived evidence from one rubric dimension referencing a step."""
+
+    dimension: str
+    score: int | None
+    notes: str
+    evaluator_type: str
+
+
+@dataclass(frozen=True)
+class AutoEvalOverlay:
+    """Runtime overlay derived from an auto_evaluation.json file."""
+
+    step_evidence: dict[str, list[DimEvidence]]  # step_id → dims citing this step
+    case_flags: list[DimEvidence]  # dims with scores but no step-level evidence
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _annotation_to_dict(ann: Annotation) -> dict[str, Any]:
+    return {
+        "annotation_id": ann.annotation_id,
+        "case_id": ann.case_id,
+        "step_id": ann.step_id,
+        "reviewer_id": ann.reviewer_id,
+        "timestamp": ann.timestamp,
+        "content": ann.content,
+        "severity": ann.severity,
+    }
+
+
+def _dict_to_annotation(d: dict[str, Any]) -> Annotation:
+    return Annotation(
+        annotation_id=d["annotation_id"],
+        case_id=d["case_id"],
+        step_id=d["step_id"],
+        reviewer_id=d["reviewer_id"],
+        timestamp=d["timestamp"],
+        content=d["content"],
+        severity=d["severity"],
+    )
+
+
+def _ann_file(case_id: str, repo_root: Path) -> Path:
+    reports_dir = repo_root / "reports"
+    path = reports_dir / f"{case_id}.annotations.json"
+    _safe_resolve_within(repo_root, path)
+    return path
+
+
+def _read_ann_file(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return result
+
+
+def _write_ann_file(path: Path, data: dict[str, Any]) -> None:
+    schema = _load_schema()
+    jsonschema.validate(instance=data, schema=schema)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Public CRUD API
+# ---------------------------------------------------------------------------
+
+
+def add_annotation(
+    case_id: str,
+    step_id: str,
+    reviewer_id: str,
+    content: str,
+    severity: Literal["none", "low", "medium", "high"],
+    repo_root: Path | None = None,
+) -> Annotation:
+    """Add a reviewer annotation to a trace step.
+
+    Appends to the case's annotation file, creating it if absent.
+    Validates all inputs and the resulting file against the JSON Schema.
+
+    Raises:
+        ValueError: if case_id, step_id, reviewer_id, or content is empty,
+                    or if severity is not a valid value.
+    """
+    if not case_id:
+        msg = "case_id must be non-empty"
+        raise ValueError(msg)
+    if not step_id:
+        msg = "step_id must be non-empty"
+        raise ValueError(msg)
+    if not reviewer_id:
+        msg = "reviewer_id must be non-empty"
+        raise ValueError(msg)
+    if not content:
+        msg = "content must be non-empty"
+        raise ValueError(msg)
+    if severity not in _VALID_SEVERITIES:
+        msg = f"severity must be one of {_VALID_SEVERITIES}, got {severity!r}"
+        raise ValueError(msg)
+
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    annotation_id = f"ann_{secrets.token_hex(4)}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    ann = Annotation(
+        annotation_id=annotation_id,
+        case_id=case_id,
+        step_id=step_id,
+        reviewer_id=reviewer_id,
+        timestamp=timestamp,
+        content=content,
+        severity=severity,
+    )
+
+    path = _ann_file(case_id, repo_root)
+
+    if path.exists():
+        data = _read_ann_file(path)
+    else:
+        data = {"case_id": case_id, "annotations": []}
+
+    data["annotations"].append(_annotation_to_dict(ann))
+    _write_ann_file(path, data)
+
+    return ann
+
+
+def get_annotations(case_id: str, repo_root: Path | None = None) -> list[Annotation]:
+    """Load all annotations for a case, sorted by timestamp ascending.
+
+    Returns an empty list if no annotation file exists.
+    """
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    path = _ann_file(case_id, repo_root)
+    if not path.exists():
+        return []
+
+    data = _read_ann_file(path)
+    annotations = [_dict_to_annotation(d) for d in data.get("annotations", [])]
+    return sorted(annotations, key=lambda a: a.timestamp)
+
+
+def delete_annotation(
+    case_id: str,
+    annotation_id: str,
+    repo_root: Path | None = None,
+) -> bool:
+    """Remove an annotation by ID.
+
+    Returns True if deleted, False if not found or file does not exist.
+    """
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    path = _ann_file(case_id, repo_root)
+    if not path.exists():
+        return False
+
+    data = _read_ann_file(path)
+    original_count = len(data.get("annotations", []))
+    data["annotations"] = [
+        a for a in data["annotations"] if a["annotation_id"] != annotation_id
+    ]
+
+    if len(data["annotations"]) == original_count:
+        return False
+
+    _write_ann_file(path, data)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Auto-eval overlay
+# ---------------------------------------------------------------------------
+
+
+def build_auto_eval_overlay(auto_eval: dict[str, Any]) -> AutoEvalOverlay:
+    """Derive an overlay from an auto_evaluation dict. Pure function — no I/O.
+
+    Returns an AutoEvalOverlay with:
+    - step_evidence: dict mapping step_id → list of DimEvidence that cite it
+    - case_flags: list of DimEvidence for dimensions with scores but no step evidence
+    """
+    step_evidence: dict[str, list[DimEvidence]] = {}
+    case_flags: list[DimEvidence] = []
+
+    dimensions = auto_eval.get("dimensions", {})
+    for dim_name, dim_data in dimensions.items():
+        if not isinstance(dim_data, dict):
+            continue
+
+        evidence = DimEvidence(
+            dimension=dim_name,
+            score=dim_data.get("score"),
+            notes=dim_data.get("notes", ""),
+            evaluator_type=dim_data.get("evaluator_type", "rule"),
+        )
+
+        evidence_step_ids: list[str] = dim_data.get("evidence_step_ids", [])
+        if evidence_step_ids:
+            for step_id in evidence_step_ids:
+                step_evidence.setdefault(step_id, []).append(evidence)
+        else:
+            case_flags.append(evidence)
+
+    return AutoEvalOverlay(step_evidence=step_evidence, case_flags=case_flags)
+
+
+def get_auto_eval_for_case(
+    case_id: str,
+    repo_root: Path | None = None,
+) -> dict[str, Any] | None:
+    """Load the best available auto_evaluation for a case.
+
+    Checks reports/{case_id}.auto_evaluation.json first, then scans runs/*/
+    for the most recently modified file.
+
+    Returns:
+        Loaded auto_evaluation dict, or None if none exists.
+    """
+    if repo_root is None:
+        repo_root = _get_repo_root()
+
+    # Primary: reports/ directory
+    reports_path = repo_root / "reports" / f"{case_id}.auto_evaluation.json"
+    try:
+        _safe_resolve_within(repo_root, reports_path)
+        if reports_path.exists():
+            loaded: dict[str, Any] = json.loads(reports_path.read_text(encoding="utf-8"))
+            return loaded
+    except (ValueError, OSError):
+        pass
+
+    # Fallback: most recent run directory
+    runs_dir = repo_root / "runs"
+    if not runs_dir.exists():
+        return None
+
+    best_path: Path | None = None
+    best_mtime: float = -1.0
+
+    for run_dir in runs_dir.iterdir():
+        if not run_dir.is_dir():
+            continue
+        candidate = run_dir / f"{case_id}.auto_evaluation.json"
+        try:
+            _safe_resolve_within(repo_root, candidate)
+            if candidate.exists():
+                mtime = candidate.stat().st_mtime
+                if mtime > best_mtime:
+                    best_mtime = mtime
+                    best_path = candidate
+        except (ValueError, OSError):
+            continue
+
+    if best_path is not None:
+        result: dict[str, Any] = json.loads(best_path.read_text(encoding="utf-8"))
+        return result
+
+    return None

--- a/src/agenteval/core/service.py
+++ b/src/agenteval/core/service.py
@@ -632,6 +632,61 @@ def compare_runs(run_a_id: str, run_b_id: str) -> Any:
     return _compare_runs(run_a_id, run_b_id)
 
 
+# ---------------------------------------------------------------------------
+# Annotations
+# ---------------------------------------------------------------------------
+
+
+def get_annotations(case_id: str) -> list[dict[str, Any]]:
+    """Return all annotations for a case as dicts, sorted by timestamp ascending."""
+    from dataclasses import asdict
+
+    from agenteval.core.annotations import get_annotations as _get_annotations
+
+    repo_root = _get_repo_root()
+    return [asdict(a) for a in _get_annotations(case_id, repo_root)]
+
+
+def add_annotation(
+    case_id: str,
+    step_id: str,
+    reviewer_id: str,
+    content: str,
+    severity: str,
+) -> dict[str, Any]:
+    """Add a reviewer annotation to a trace step. Returns the annotation as a dict."""
+    from dataclasses import asdict
+
+    from agenteval.core.annotations import add_annotation as _add_annotation
+
+    repo_root = _get_repo_root()
+    ann = _add_annotation(
+        case_id=case_id,
+        step_id=step_id,
+        reviewer_id=reviewer_id,
+        content=content,
+        severity=severity,  # type: ignore[arg-type]
+        repo_root=repo_root,
+    )
+    return asdict(ann)
+
+
+def delete_annotation(case_id: str, annotation_id: str) -> bool:
+    """Remove an annotation by ID. Returns True if deleted, False if not found."""
+    from agenteval.core.annotations import delete_annotation as _delete_annotation
+
+    repo_root = _get_repo_root()
+    return _delete_annotation(case_id, annotation_id, repo_root)
+
+
+def get_auto_eval_for_case(case_id: str) -> dict[str, Any] | None:
+    """Load the best available auto_evaluation for a case. Returns dict or None."""
+    from agenteval.core.annotations import get_auto_eval_for_case as _get_auto_eval
+
+    repo_root = _get_repo_root()
+    return _get_auto_eval(case_id, repo_root)
+
+
 def get_dataset_tags(dataset_dir: Path | None = None) -> set[str]:
     """Return the union of all tags across the dataset. Used by UI for tag dropdown.
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,445 @@
+"""Unit tests for agenteval.core.annotations module."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agenteval.core.annotations import (
+    Annotation,
+    AutoEvalOverlay,
+    DimEvidence,
+    add_annotation,
+    build_auto_eval_overlay,
+    delete_annotation,
+    get_annotations,
+    get_auto_eval_for_case,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Return a temporary repo root with reports/ and runs/ directories."""
+    (tmp_path / "reports").mkdir()
+    (tmp_path / "runs").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def sample_auto_eval() -> dict:  # type: ignore[type-arg]
+    """Minimal auto_evaluation dict with one step-cited and one case-level dimension."""
+    return {
+        "case_id": "case_001",
+        "scoring_type": "auto",
+        "rubric_version": "v1",
+        "dimensions": {
+            "tool_use": {
+                "dimension_name": "tool_use",
+                "score": 1,
+                "weight": 1.0,
+                "scale": "0-2",
+                "evidence_step_ids": ["step_2"],
+                "notes": "Incomplete tool execution",
+                "evaluator_type": "rule",
+            },
+            "security_safety": {
+                "dimension_name": "security_safety",
+                "score": 2,
+                "weight": 1.5,
+                "scale": "0-2",
+                "evidence_step_ids": [],
+                "notes": "No security issues found",
+                "evaluator_type": "rule",
+            },
+        },
+        "auto_tags": [],
+        "metadata": {"timestamp": "2026-05-04T10:00:00+00:00"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# T010: add_annotation()
+# ---------------------------------------------------------------------------
+
+
+class TestAddAnnotation:
+    def test_creates_annotation_with_correct_fields(self, repo_root: Path) -> None:
+        ann = add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Test note",
+            severity="low",
+            repo_root=repo_root,
+        )
+        assert isinstance(ann, Annotation)
+        assert ann.case_id == "case_001"
+        assert ann.step_id == "step_1"
+        assert ann.reviewer_id == "alice"
+        assert ann.content == "Test note"
+        assert ann.severity == "low"
+        assert ann.annotation_id.startswith("ann_")
+        assert len(ann.annotation_id) == 12  # ann_ + 8 hex
+
+    def test_creates_file_on_first_write(self, repo_root: Path) -> None:
+        add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Test note",
+            severity="none",
+            repo_root=repo_root,
+        )
+        ann_file = repo_root / "reports" / "case_001.annotations.json"
+        assert ann_file.exists()
+
+    def test_appends_on_subsequent_writes(self, repo_root: Path) -> None:
+        for i in range(3):
+            add_annotation(
+                case_id="case_001",
+                step_id=f"step_{i}",
+                reviewer_id="alice",
+                content=f"Note {i}",
+                severity="low",
+                repo_root=repo_root,
+            )
+        annotations = get_annotations("case_001", repo_root)
+        assert len(annotations) == 3
+
+    def test_raises_on_empty_content(self, repo_root: Path) -> None:
+        with pytest.raises(ValueError, match="content"):
+            add_annotation(
+                case_id="case_001",
+                step_id="step_1",
+                reviewer_id="alice",
+                content="",
+                severity="low",
+                repo_root=repo_root,
+            )
+
+    def test_raises_on_empty_case_id(self, repo_root: Path) -> None:
+        with pytest.raises(ValueError, match="case_id"):
+            add_annotation(
+                case_id="",
+                step_id="step_1",
+                reviewer_id="alice",
+                content="Note",
+                severity="low",
+                repo_root=repo_root,
+            )
+
+    def test_raises_on_empty_step_id(self, repo_root: Path) -> None:
+        with pytest.raises(ValueError, match="step_id"):
+            add_annotation(
+                case_id="case_001",
+                step_id="",
+                reviewer_id="alice",
+                content="Note",
+                severity="low",
+                repo_root=repo_root,
+            )
+
+    def test_raises_on_empty_reviewer_id(self, repo_root: Path) -> None:
+        with pytest.raises(ValueError, match="reviewer_id"):
+            add_annotation(
+                case_id="case_001",
+                step_id="step_1",
+                reviewer_id="",
+                content="Note",
+                severity="low",
+                repo_root=repo_root,
+            )
+
+    def test_raises_on_invalid_severity(self, repo_root: Path) -> None:
+        with pytest.raises(ValueError, match="severity"):
+            add_annotation(
+                case_id="case_001",
+                step_id="step_1",
+                reviewer_id="alice",
+                content="Note",
+                severity="critical",  # type: ignore[arg-type]
+                repo_root=repo_root,
+            )
+
+    def test_file_is_valid_per_schema(self, repo_root: Path) -> None:
+        import jsonschema
+
+        schema_path = Path(__file__).parent.parent / "schemas" / "annotation_schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Test note",
+            severity="high",
+            repo_root=repo_root,
+        )
+        ann_file = repo_root / "reports" / "case_001.annotations.json"
+        data = json.loads(ann_file.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)  # raises on invalid
+
+
+# ---------------------------------------------------------------------------
+# T011: get_annotations()
+# ---------------------------------------------------------------------------
+
+
+class TestGetAnnotations:
+    def test_returns_empty_list_when_no_file(self, repo_root: Path) -> None:
+        result = get_annotations("case_999", repo_root)
+        assert result == []
+
+    def test_returns_all_annotations(self, repo_root: Path) -> None:
+        for i in range(4):
+            add_annotation(
+                case_id="case_001",
+                step_id=f"step_{i}",
+                reviewer_id="alice",
+                content=f"Note {i}",
+                severity="none",
+                repo_root=repo_root,
+            )
+        result = get_annotations("case_001", repo_root)
+        assert len(result) == 4
+
+    def test_sorted_by_timestamp_ascending(self, repo_root: Path) -> None:
+        for i in range(3):
+            add_annotation(
+                case_id="case_001",
+                step_id=f"step_{i}",
+                reviewer_id="alice",
+                content=f"Note {i}",
+                severity="none",
+                repo_root=repo_root,
+            )
+        result = get_annotations("case_001", repo_root)
+        timestamps = [a.timestamp for a in result]
+        assert timestamps == sorted(timestamps)
+
+    def test_returns_annotation_dataclass_instances(self, repo_root: Path) -> None:
+        add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Note",
+            severity="medium",
+            repo_root=repo_root,
+        )
+        result = get_annotations("case_001", repo_root)
+        assert all(isinstance(a, Annotation) for a in result)
+
+
+# ---------------------------------------------------------------------------
+# T012: delete_annotation()
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAnnotation:
+    def test_returns_true_when_deleted(self, repo_root: Path) -> None:
+        ann = add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Note",
+            severity="low",
+            repo_root=repo_root,
+        )
+        result = delete_annotation("case_001", ann.annotation_id, repo_root)
+        assert result is True
+
+    def test_returns_false_when_not_found(self, repo_root: Path) -> None:
+        add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Note",
+            severity="low",
+            repo_root=repo_root,
+        )
+        result = delete_annotation("case_001", "ann_00000000", repo_root)
+        assert result is False
+
+    def test_returns_false_when_no_file(self, repo_root: Path) -> None:
+        result = delete_annotation("case_999", "ann_00000000", repo_root)
+        assert result is False
+
+    def test_annotation_removed_from_file(self, repo_root: Path) -> None:
+        ann = add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Note",
+            severity="low",
+            repo_root=repo_root,
+        )
+        delete_annotation("case_001", ann.annotation_id, repo_root)
+        remaining = get_annotations("case_001", repo_root)
+        assert not any(a.annotation_id == ann.annotation_id for a in remaining)
+
+    def test_other_annotations_preserved_after_delete(self, repo_root: Path) -> None:
+        ann1 = add_annotation(
+            case_id="case_001",
+            step_id="step_1",
+            reviewer_id="alice",
+            content="Note 1",
+            severity="low",
+            repo_root=repo_root,
+        )
+        ann2 = add_annotation(
+            case_id="case_001",
+            step_id="step_2",
+            reviewer_id="alice",
+            content="Note 2",
+            severity="high",
+            repo_root=repo_root,
+        )
+        delete_annotation("case_001", ann1.annotation_id, repo_root)
+        remaining = get_annotations("case_001", repo_root)
+        assert len(remaining) == 1
+        assert remaining[0].annotation_id == ann2.annotation_id
+
+
+# ---------------------------------------------------------------------------
+# T013: build_auto_eval_overlay()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAutoEvalOverlay:
+    def test_step_evidence_populated_when_evidence_step_ids_present(
+        self, sample_auto_eval: dict  # type: ignore[type-arg]
+    ) -> None:
+        overlay = build_auto_eval_overlay(sample_auto_eval)
+        assert "step_2" in overlay.step_evidence
+        dims = overlay.step_evidence["step_2"]
+        assert any(d.dimension == "tool_use" for d in dims)
+
+    def test_case_flags_populated_when_evidence_step_ids_empty(
+        self, sample_auto_eval: dict  # type: ignore[type-arg]
+    ) -> None:
+        overlay = build_auto_eval_overlay(sample_auto_eval)
+        assert any(f.dimension == "security_safety" for f in overlay.case_flags)
+
+    def test_empty_auto_eval_returns_empty_overlay(self) -> None:
+        empty = {
+            "case_id": "case_001",
+            "dimensions": {},
+            "scoring_type": "auto",
+            "rubric_version": "v1",
+            "auto_tags": [],
+            "metadata": {"timestamp": "2026-05-04T10:00:00+00:00"},
+        }
+        overlay = build_auto_eval_overlay(empty)
+        assert overlay.step_evidence == {}
+        assert overlay.case_flags == []
+
+    def test_returns_auto_eval_overlay_instance(
+        self, sample_auto_eval: dict  # type: ignore[type-arg]
+    ) -> None:
+        overlay = build_auto_eval_overlay(sample_auto_eval)
+        assert isinstance(overlay, AutoEvalOverlay)
+
+    def test_dim_evidence_fields_populated(
+        self, sample_auto_eval: dict  # type: ignore[type-arg]
+    ) -> None:
+        overlay = build_auto_eval_overlay(sample_auto_eval)
+        dim = overlay.step_evidence["step_2"][0]
+        assert isinstance(dim, DimEvidence)
+        assert dim.dimension == "tool_use"
+        assert dim.score == 1
+        assert dim.evaluator_type == "rule"
+
+    def test_multiple_steps_cited_by_same_dimension(self) -> None:
+        auto_eval = {
+            "case_id": "case_001",
+            "dimensions": {
+                "tool_use": {
+                    "dimension_name": "tool_use",
+                    "score": 0,
+                    "weight": 1.0,
+                    "scale": "0-2",
+                    "evidence_step_ids": ["step_1", "step_3"],
+                    "notes": "Two bad steps",
+                    "evaluator_type": "rule",
+                }
+            },
+            "scoring_type": "auto",
+            "rubric_version": "v1",
+            "auto_tags": [],
+            "metadata": {"timestamp": "2026-05-04T10:00:00+00:00"},
+        }
+        overlay = build_auto_eval_overlay(auto_eval)
+        assert "step_1" in overlay.step_evidence
+        assert "step_3" in overlay.step_evidence
+
+
+# ---------------------------------------------------------------------------
+# T014: get_auto_eval_for_case()
+# ---------------------------------------------------------------------------
+
+
+class TestGetAutoEvalForCase:
+    def test_returns_none_when_no_file_exists(self, repo_root: Path) -> None:
+        result = get_auto_eval_for_case("case_999", repo_root)
+        assert result is None
+
+    def test_returns_dict_when_reports_file_exists(
+        self,
+        repo_root: Path,
+        sample_auto_eval: dict,  # type: ignore[type-arg]
+    ) -> None:
+        reports_dir = repo_root / "reports"
+        ann_path = reports_dir / "case_001.auto_evaluation.json"
+        ann_path.write_text(json.dumps(sample_auto_eval), encoding="utf-8")
+
+        result = get_auto_eval_for_case("case_001", repo_root)
+        assert result is not None
+        assert result["case_id"] == "case_001"
+
+    def test_prefers_reports_over_runs(
+        self,
+        repo_root: Path,
+        sample_auto_eval: dict,  # type: ignore[type-arg]
+    ) -> None:
+        # Write different data to reports/ vs runs/
+        reports_copy = dict(sample_auto_eval)
+        reports_copy["rubric_version"] = "from_reports"
+
+        run_copy = dict(sample_auto_eval)
+        run_copy["rubric_version"] = "from_runs"
+
+        reports_dir = repo_root / "reports"
+        (reports_dir / "case_001.auto_evaluation.json").write_text(
+            json.dumps(reports_copy), encoding="utf-8"
+        )
+
+        run_dir = repo_root / "runs" / "run_001"
+        run_dir.mkdir(parents=True)
+        (run_dir / "case_001.auto_evaluation.json").write_text(
+            json.dumps(run_copy), encoding="utf-8"
+        )
+
+        result = get_auto_eval_for_case("case_001", repo_root)
+        assert result is not None
+        assert result["rubric_version"] == "from_reports"
+
+    def test_falls_back_to_runs_when_no_reports_file(
+        self,
+        repo_root: Path,
+        sample_auto_eval: dict,  # type: ignore[type-arg]
+    ) -> None:
+        run_dir = repo_root / "runs" / "run_001"
+        run_dir.mkdir(parents=True)
+        (run_dir / "case_001.auto_evaluation.json").write_text(
+            json.dumps(sample_auto_eval), encoding="utf-8"
+        )
+
+        result = get_auto_eval_for_case("case_001", repo_root)
+        assert result is not None
+        assert result["case_id"] == "case_001"


### PR DESCRIPTION
## Summary

- New `src/agenteval/core/annotations.py` module: `Annotation`, `DimEvidence`, `AutoEvalOverlay` dataclasses, CRUD (`add_annotation`, `get_annotations`, `delete_annotation`), `build_auto_eval_overlay` (pure function), `get_auto_eval_for_case` (checks `reports/` then `runs/`)
- New `schemas/annotation_schema.json`: JSON Schema validated on every write
- New `app/components/annotation.py`: `render_annotation_form` + `render_annotation_list` Streamlit widgets
- Enhanced `app/page_inspect.py`: inline annotations (US1), auto-score overlay with step badges + sidebar flags (US2), jump-to-step evidence linking with highlight (US3)
- 4 new service layer wrappers in `service.py`
- 28 new unit tests; 495 total passing, ruff clean, mypy clean

## User Stories

- **US1 (Inline Annotations)**: Add Note form per trace step, severity badges (none/low/medium/high), delete, persists to `reports/{case_id}.annotations.json`
- **US2 (Auto-Score Overlay)**: `:red-badge[dimension: score]` on flagged steps when auto-evaluation exists; sidebar "Evaluation Flags" expander for case-level dimensions with empty `evidence_step_ids`
- **US3 (Evidence Linking)**: "→ step_N" jump buttons in Evaluation Template section; clicking sets `st.session_state["inspect_highlighted_step"]`; target step renders with violet highlighted border; cleared on case change

## Test plan

- [ ] Run `pytest tests/test_annotations.py -v` — 28 tests pass
- [ ] Run `pytest tests/ -q` — 495 tests pass, no regressions
- [ ] Open Inspect page, select a case, click "Add Note" on a step — note saves and appears on reload
- [ ] Run auto-scoring on a case, reload Inspect — flagged steps show red dimension badges
- [ ] Click "→ step_N" in Evaluation section — step scrolls/highlights in violet
- [ ] Delete an annotation — it disappears from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)