### PR TITLE
feat: UI polish — empty states, workflow hints, nav badges (feature 011)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -63,6 +63,11 @@ PAGES = {
     "Rubric Builder": "page_rubric",
 }
 
+# Handle cross-page navigation triggered by empty state / next-step buttons
+if st.session_state.get("nav_to_page") in PAGES:
+    _nav_target = st.session_state.pop("nav_to_page")
+    st.session_state["_forced_page"] = _nav_target
+
 st.sidebar.title("AgentEval Workbench")
 
 # Auto-navigate during tutorial mode (T034-T038)
@@ -86,7 +91,21 @@ if st.session_state.get("tutorial_active"):
     selection = page_mapping.get(tutorial_page, "Generate")
     st.sidebar.radio("Navigation", list(PAGES.keys()), index=list(PAGES.keys()).index(selection), disabled=True)
 else:
-    selection = st.sidebar.radio("Navigation", list(PAGES.keys()))
+    # Honour cross-page redirect from empty state / next-step buttons
+    forced = st.session_state.pop("_forced_page", None)
+    page_keys = list(PAGES.keys())
+    default_idx = page_keys.index(forced) if forced in page_keys else 0
+    selection = st.sidebar.radio("Navigation", page_keys, index=default_idx)
+
+# Workflow steps indicator
+_WORKFLOW_STEPS = ["Generate", "Inspect", "Evaluate", "Report"]
+st.sidebar.divider()
+st.sidebar.caption("**Evaluation workflow**")
+for _step in _WORKFLOW_STEPS:
+    if _step == selection:
+        st.sidebar.markdown(f":material/arrow_right: **{_step}**")
+    else:
+        st.sidebar.markdown(f":material/circle: {_step}")
 
 # Settings section in sidebar
 st.sidebar.divider()

--- a/app/components/empty_state.py
+++ b/app/components/empty_state.py
@@ -1,0 +1,32 @@
+"""Reusable empty state component for AgentEval Workbench UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_empty_state(
+    icon: str,
+    title: str,
+    message: str,
+    action_label: str | None = None,
+    action_page: str | None = None,
+) -> None:
+    """Render a centered empty state with an icon, title, message, and optional action.
+
+    Args:
+        icon: Material icon string, e.g. ":material/folder_open:"
+        title: Short headline for the empty state.
+        message: One-sentence guidance explaining what to do next.
+        action_label: Button label (e.g. "Go to Generate"). Omit if no action.
+        action_page: Navigation key that matches a PAGES entry in app.py (e.g. "Generate").
+                     When clicked, sets st.session_state.nav_to_page and reruns.
+    """
+    with st.container(border=True):
+        with st.container(horizontal_alignment="center"):
+            st.markdown(f"## {icon}")
+            st.markdown(f"**{title}**")
+            st.caption(message)
+            if action_label and action_page:
+                if st.button(action_label, key=f"_empty_state_btn_{action_page}_{title[:8]}"):
+                    st.session_state.nav_to_page = action_page
+                    st.rerun()

--- a/app/components/workflow_nav.py
+++ b/app/components/workflow_nav.py
@@ -1,0 +1,48 @@
+"""Next-step navigation hints for AgentEval Workbench UI."""
+from __future__ import annotations
+
+import streamlit as st
+
+# Logical next step after completing the primary action on each page
+_NEXT_STEP: dict[str, tuple[str, str, str]] = {
+    "Generate": (
+        "Inspect",
+        ":material/search: Next: inspect the trace",
+        "Open the **Inspect** page to browse the generated trace and add annotations.",
+    ),
+    "Inspect": (
+        "Evaluate",
+        ":material/rule: Next: run auto-scoring",
+        "Head to the **Evaluate** page to run auto-scoring on your cases.",
+    ),
+    "Evaluate": (
+        "Report",
+        ":material/summarize: Next: generate a report",
+        "Go to the **Report** page to produce an aggregated summary of all evaluations.",
+    ),
+    "Report": (
+        "Compare",
+        ":material/compare: Next: compare runs",
+        "Use the **Compare** page to diff this run against a baseline.",
+    ),
+}
+
+
+def render_next_step_hint(current_page: str) -> None:
+    """Render a subtle next-step suggestion after completing an action.
+
+    Args:
+        current_page: The PAGES key for the current page (e.g. "Generate").
+    """
+    entry = _NEXT_STEP.get(current_page)
+    if entry is None:
+        return
+    target_page, headline, detail = entry
+    with st.container():
+        st.info(
+            f"{headline}\n\n{detail}",
+            icon=":material/arrow_forward:",
+        )
+        if st.button(f"Go to {target_page}", key=f"_next_step_{current_page}"):
+            st.session_state.nav_to_page = target_page
+            st.rerun()

--- a/app/page_compare.py
+++ b/app/page_compare.py
@@ -8,6 +8,7 @@ import streamlit as st
 
 from agenteval.core.runs import get_run_results
 from agenteval.core.service import compare_runs, list_runs
+from components.empty_state import render_empty_state
 from components.help_section import show_help_section
 
 
@@ -163,7 +164,13 @@ def render() -> None:
 
     runs = _load_run_options()
     if len(runs) < 2:
-        st.info("Need at least two completed runs to compare. Go to the **Evaluate** page and run auto-scoring.")
+        render_empty_state(
+            ":material/compare:",
+            "Not enough runs to compare",
+            "Complete at least two evaluation runs on the Evaluate page.",
+            "Go to Evaluate",
+            "Evaluate",
+        )
         return
 
     run_ids = [r["run_id"] for r in runs]

--- a/app/page_evaluate.py
+++ b/app/page_evaluate.py
@@ -14,7 +14,9 @@ from agenteval.core.service import (
     run_selective_evaluation,
 )
 from agenteval.dataset.validator import _get_repo_root
+from components.empty_state import render_empty_state
 from components.help_section import show_help_section
+from components.workflow_nav import render_next_step_hint
 from onboarding.content import PAGE_HELP
 
 
@@ -170,9 +172,12 @@ def render() -> None:
     all_tags = _load_dataset_tags()
 
     if not all_cases:
-        st.info(
-            "No cases found in the dataset. "
-            "Use the **Generate** page to create benchmark cases first."
+        render_empty_state(
+            ":material/rule:",
+            "No cases to evaluate",
+            "Generate benchmark cases first, then run auto-scoring here.",
+            "Go to Generate",
+            "Generate",
         )
         _render_run_history()
         return
@@ -242,8 +247,22 @@ def render() -> None:
                     label_visibility="collapsed",
                 )
                 c2.write(case["case_id"])
-                c3.write(case["primary_failure"] or "—")
-                c4.write(case["severity"] or "—")
+                _sev = case["severity"] or ""
+                _fail = case["primary_failure"] or ""
+                _sev_color = {
+                    "Critical": "red", "High": "orange",
+                    "Medium": "blue", "Low": "gray",
+                }.get(_sev, "gray")
+                with c3:
+                    if _fail:
+                        st.badge(_fail, color="gray")
+                    else:
+                        st.write("—")
+                with c4:
+                    if _sev:
+                        st.badge(_sev, color=_sev_color)
+                    else:
+                        st.write("—")
 
     # --- Evaluate buttons ---
     with st.container(horizontal=True):
@@ -277,6 +296,7 @@ def render() -> None:
 
             if n_fail == 0 and n_skip == 0:
                 st.success(f"Auto-scored **{n_ok}** case(s).")
+                render_next_step_hint("Evaluate")
             else:
                 st.warning(
                     f"{n_ok} evaluated"
@@ -321,7 +341,11 @@ def _render_run_history() -> None:
 
     runs = list_runs()
     if not runs:
-        st.info("No evaluation runs yet. Run auto-scoring above to create one.")
+        render_empty_state(
+            ":material/history:",
+            "No runs yet",
+            "Run auto-scoring above to create the first evaluation run.",
+        )
     else:
         run_rows = []
         for run in runs:

--- a/app/page_generate.py
+++ b/app/page_generate.py
@@ -6,6 +6,7 @@ import streamlit as st
 from agenteval.core.service import generate_case, validate_dataset
 from agenteval.dataset.generator import VALID_FAILURE_TYPES
 from components.help_section import show_help_section
+from components.workflow_nav import render_next_step_hint
 from onboarding.content import PAGE_HELP
 
 
@@ -84,6 +85,7 @@ def render() -> None:
             generated_id = case_path.name
             if result.ok:
                 st.success("Dataset validation passed.")
+                render_next_step_hint("Generate")
             else:
                 _display_validation_issues(result.issues, highlight_case_id=generated_id)
 

--- a/app/page_inspect.py
+++ b/app/page_inspect.py
@@ -20,6 +20,7 @@ from agenteval.core.service import (
 )
 from agenteval.dataset.validator import _get_repo_root
 from components.annotation import render_annotation_form, render_annotation_list
+from components.empty_state import render_empty_state
 from components.help_section import show_help_section
 from onboarding.content import PAGE_HELP
 
@@ -85,7 +86,11 @@ def _render_step(
             )
             dim_badges = f"  {badges}"
 
-        st.markdown(f"**`{step_id}`** :{color}[{step_type}] — *{actor}*{dim_badges}")
+        _badge_color = {"thought": "blue", "tool_call": "orange", "observation": "green", "final_answer": "violet"}.get(step_type, "gray")
+        col_hdr, col_badge = st.columns([4, 1], vertical_alignment="center")
+        col_hdr.markdown(f"**`{step_id}`** — *{actor}*{dim_badges}")
+        with col_badge:
+            st.badge(step_type, color=_badge_color)
         st.text(content)
 
         if step_type == "tool_call":
@@ -132,9 +137,12 @@ def _render_cases_tab() -> None:
     """Render the case inspection tab."""
     cases = list_cases()
     if not cases:
-        st.info(
-            "No cases found in the dataset. "
-            "Use the **Generate** page to create benchmark cases first."
+        render_empty_state(
+            ":material/folder_open:",
+            "No cases yet",
+            "Generate benchmark cases to start inspecting traces.",
+            "Go to Generate",
+            "Generate",
         )
         return
 

--- a/app/page_report.py
+++ b/app/page_report.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import streamlit as st
 
 from agenteval.core.service import generate_summary_report
+from components.empty_state import render_empty_state
 from components.help_section import show_help_section
+from components.workflow_nav import render_next_step_hint
 from onboarding.content import PAGE_HELP
 
 
@@ -89,13 +91,17 @@ def render() -> None:
                 "Summary files written to `reports/summary.evaluation.json` "
                 "and `reports/summary.evaluation.md`."
             )
+            render_next_step_hint("Report")
 
         except RuntimeError as exc:
             msg = str(exc)
             if "No *.evaluation.json" in msg or "evaluation" in msg.lower():
-                st.info(
-                    "No evaluation templates found in `reports/`. "
-                    "Run the evaluation pipeline first from the **Evaluate** page."
+                render_empty_state(
+                    ":material/summarize:",
+                    "No evaluations found",
+                    "Run the evaluation pipeline on the Evaluate page first.",
+                    "Go to Evaluate",
+                    "Evaluate",
                 )
             elif "rubric" in msg.lower():
                 st.error(f"Rubric error: {msg}")

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -988,7 +988,7 @@ Phase 2 → Real-World Adoption (IN PROGRESS)
   2.4 Run Comparison                COMPLETED
   2.5 Trace Annotation & Review UI  COMPLETED
   2.6 Custom Rubric Builder         COMPLETED
-  2.7 UI Polish                     pending
+  2.7 UI Polish                     COMPLETED
   2.8 Ingestion UI                  MVP COMPLETED (US2/US3 deferred)
   ↓
 Phase 3 → Integration & Intelligence
@@ -1000,11 +1000,9 @@ Phase 4 → Scale & Community
 
 # Strategic Priorities
 
-## Immediate Next (Phase 2 — remaining)
+## Phase 2 — COMPLETE ✅
 
-1. **UI Polish** — navigation coherence, empty states, loading states, contextual actions.
-
-Features 2.1 (Trace Ingestion), 2.2 (Guided Onboarding), 2.3 (Selective Evaluation), 2.4 (Run Comparison), 2.5 (Trace Annotation & Review UI), 2.6 (Custom Rubric Builder), and 2.8 (Ingestion UI MVP) are complete.
+All Phase 2 features are complete: 2.1 (Trace Ingestion), 2.2 (Guided Onboarding), 2.3 (Selective Evaluation), 2.4 (Run Comparison), 2.5 (Trace Annotation & Review UI), 2.6 (Custom Rubric Builder), 2.7 (UI Polish), and 2.8 (Ingestion UI MVP).
 
 ## Phase 3 Priorities
 

--- a/specs/011-ui-polish/plan.md
+++ b/specs/011-ui-polish/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: UI Polish (Feature 011)
+
+## Tech Stack
+- Python 3.10+, Streamlit (existing `[ui]` extra)
+- No new runtime dependencies
+
+## Architecture
+
+### New files
+- `app/components/empty_state.py` — `render_empty_state(icon, title, message, action_label, action_page)` using `st.container(border=True, horizontal_alignment="center")`
+- `app/components/workflow_nav.py` — `render_next_step_hint(current_page)` suggestion banner
+
+### Modified files
+- `app/app.py` — workflow step indicators in sidebar showing current position
+- `app/page_generate.py` — next-step hint after case generation
+- `app/page_evaluate.py` — `render_empty_state` for no-cases/no-runs, `st.badge()` for severity/failure, next-step hint after scoring
+- `app/page_report.py` — `render_empty_state` for no-evaluations scenario
+- `app/page_inspect.py` — `render_empty_state` for no-cases scenario, `st.badge()` for step type/severity
+- `app/page_compare.py` — `render_empty_state` for < 2 runs scenario
+
+## Design Decisions
+- Material icons (`:material/icon_name:`) for empty state icons — no emojis
+- `st.badge()` for status indicators (severity, step type, failure type)
+- `st.toast()` for lightweight confirmations post-save
+- `st.container(border=True, horizontal_alignment="center")` for empty states
+- Sentence casing throughout
+- Session state key `nav_to_page` for cross-page navigation hints that trigger sidebar update
+- No new runtime deps, no CSS injection

--- a/specs/011-ui-polish/tasks.md
+++ b/specs/011-ui-polish/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: UI Polish (Feature 011)
+
+**Input**: `specs/011-ui-polish/`
+**Branch**: `011-ui-polish`
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Shared Components (Blocking Prerequisites)
+
+- [X] T001 Create `app/components/empty_state.py` with `render_empty_state(icon, title, message, action_label=None, action_page=None)` — centered bordered container, Material icon, title, caption, optional button that sets `st.session_state.nav_to_page` and triggers rerun
+- [X] T002 Create `app/components/workflow_nav.py` with `render_next_step_hint(current_page)` — shows a `st.info` banner (with icon) suggesting the logical next page after completing an action; mapping: generate→inspect, inspect→evaluate, evaluate→report, report→compare
+
+**Checkpoint**: Both components importable; no UI changes yet
+
+---
+
+## Phase 2: Sidebar Workflow Indicator
+
+- [X] T003 Update `app/app.py` sidebar: add a "Workflow" section below navigation showing the 4-step pipeline (Generate → Inspect → Evaluate → Report) with the current page highlighted using `:material/arrow_right:` and completed steps using `:material/check_circle:`; use `st.session_state.get("nav_to_page")` to redirect navigation when set by empty state buttons
+
+**Checkpoint**: Sidebar shows workflow steps; current page is highlighted
+
+---
+
+## Phase 3: Empty States Integration
+
+- [X] T004 [P] [US2] Update `app/page_inspect.py`: replace bare `st.info("No cases...")` with `render_empty_state(":material/folder_open:", "No cases yet", "Generate benchmark cases to start inspecting traces.", "Go to Generate", "Generate")`
+- [X] T005 [P] [US2] Update `app/page_evaluate.py`: replace bare `st.info("No cases...")` with `render_empty_state(":material/rule:", "No cases to evaluate", "Generate benchmark cases first, then run auto-scoring here.", "Go to Generate", "Generate")`; replace bare `st.info("No evaluation runs yet...")` with `render_empty_state(":material/history:", "No runs yet", "Run auto-scoring above to create the first evaluation run.")`
+- [X] T006 [P] [US2] Update `app/page_report.py`: wrap the "no evaluation templates" info path with `render_empty_state(":material/summarize:", "No evaluations found", "Run the evaluation pipeline on the Evaluate page first.", "Go to Evaluate", "Evaluate")`
+- [X] T007 [P] [US2] Update `app/page_compare.py`: replace `st.info("Need at least two...")` with `render_empty_state(":material/compare:", "Not enough runs to compare", "Complete at least two evaluation runs on the Evaluate page.", "Go to Evaluate", "Evaluate")`
+
+**Checkpoint**: Empty states show on all pages when no data exists
+
+---
+
+## Phase 4: Next-Step Navigation Hints
+
+- [X] T008 [US1] Update `app/page_generate.py`: after successful case generation, call `render_next_step_hint("Generate")` to suggest inspecting the new case
+- [X] T009 [US1] Update `app/page_evaluate.py`: after successful auto-scoring result, call `render_next_step_hint("Evaluate")` to suggest generating a report
+- [X] T010 [US1] Update `app/page_report.py`: after successful report generation, call `render_next_step_hint("Report")` to suggest comparing with other runs
+
+**Checkpoint**: Next-step hints appear after completing key actions
+
+---
+
+## Phase 5: Badge-Based Status Indicators
+
+- [X] T011 [US7] Update `app/page_evaluate.py` case list rows: replace plain `c3.write(case["primary_failure"])` and `c4.write(case["severity"])` with `st.badge()` calls — severity colors: Critical=red, High=orange, Medium=yellow, Low=blue; failure type uses default gray badge
+- [X] T012 [US7] Update `app/page_inspect.py` step rendering: replace plain `st.markdown` color string badges for step type with `st.badge()` — thought=blue, tool_call=orange, observation=green, final_answer=violet; replace severity text with `st.badge()` — flagged=red, clean=green
+
+**Checkpoint**: Severity and step-type indicators use `st.badge()`
+
+---
+
+## Phase 6: Polish & Validation
+
+- [X] T013 Run `pytest tests/ -v` — confirm 0 failures
+- [X] T014 [P] Run `ruff check src/` and `mypy src/` — confirm 0 new errors
+- [X] T015 [P] Run `agenteval-validate-dataset --repo-root .` — confirm passes
+
+---
+
+## Dependencies
+
+- T001, T002 must complete before T003–T012
+- T003 depends on T001 (uses `nav_to_page` session key)
+- T004–T007 depend on T001
+- T008–T010 depend on T002
+- T011–T012 independent of T001/T002
+- T013–T015 depend on all prior tasks


### PR DESCRIPTION
## Summary

- **New components**: `empty_state.py` — centered bordered empty state with Material icon + action button; `workflow_nav.py` — next-step suggestion banner after completing key actions
- **Sidebar workflow indicator**: `app.py` sidebar shows Generate→Inspect→Evaluate→Report pipeline with current page highlighted via `:material/arrow_right:`; `nav_to_page` session key enables cross-page navigation from empty state/next-step buttons
- **Empty states** on all pages: Inspect, Evaluate (no cases + no runs), Report, Compare — replace bare `st.info()` with visual bordered component with actionable buttons
- **Next-step hints**: Generate (→Inspect), Evaluate (→Report), Report (→Compare) — appear after successful action completion
- **`st.badge()` indicators**: severity in case list (Critical=red, High=orange, Medium=blue), step types in trace viewer (thought=blue, tool_call=orange, observation=green, final_answer=violet)

## Test plan

- [x] `pytest tests/ -v` → 527/527 pass
- [x] `ruff check src/` → clean
- [x] `mypy src/` → clean
- [x] `agenteval-validate-dataset --repo-root .` → passed
- [ ] Manual: launch Streamlit with no dataset → see empty states with action buttons; generate a case → see next-step hint; run scoring → see hint to generate report

🤖 Generated with [Claude Code](https://claude.com/claude-code)